### PR TITLE
Make $DestinationPath a mandatory parameter

### DIFF
--- a/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
+++ b/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
@@ -272,7 +272,7 @@ function Expand-Archive
         [Alias("PSPath")]
         [string] $LiteralPath,
 
-        [parameter (mandatory=$false,
+        [parameter (mandatory=$true,
         Position=1,
         ValueFromPipeline=$false,
         ValueFromPipelineByPropertyName=$false)]


### PR DESCRIPTION
Was set to false but had ValidateNotNullOrEmpty attribute making it required.