### PR TITLE
CompressArchiveCommand: fix issues with progress formatting

### DIFF
--- a/src/CompressArchiveCommand.cs
+++ b/src/CompressArchiveCommand.cs
@@ -203,7 +203,7 @@ namespace Microsoft.PowerShell.Archive
                 {
                     // Update progress
                     var percentComplete = numberOfAddedItems / (float)numberOfAdditions * 100f;
-                    progressRecord.StatusDescription = string.Format(Messages.ProgressDisplay, "{percentComplete:0.0}");
+                    progressRecord.StatusDescription = string.Format(Messages.ProgressDisplay, $"{percentComplete:0.0}");
                     WriteProgress(progressRecord);
 
                     if (ShouldProcess(target: entry.FileSystemInfo.FullName, action: Messages.Add))
@@ -219,7 +219,7 @@ namespace Microsoft.PowerShell.Archive
 
                 // Once all items in the archive are processed, show progress as 100%
                 // This code is here and not in the loop because we want it to run even if there are no items to add to the archive
-                progressRecord.StatusDescription = string.Format(Messages.ProgressDisplay, "100.0");
+                progressRecord.StatusDescription = string.Format(Messages.ProgressDisplay, $"{100.0:0.0}");
                 WriteProgress(progressRecord);
             }
             finally


### PR DESCRIPTION
# PR Summary + PR Context

- The progress now is actually reported (I guess missing `$` was a typo).
- The progress now uses current culture (that's why I've replaced hard-coded `100.0` with `$"{100.0:0.0}"`: I assume the idea was to use local culture to format the number; certain cultures may use different number separator and formatting).
