### PR TITLE
Copy Unix File Permissions In Zip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ test/tools/Modules/SelfSignedCertificate/
 
 # BenchmarkDotNet artifacts
 test/perf/BenchmarkDotNet.Artifacts/
+.idea/


### PR DESCRIPTION
# PR Summary

Aims to add support for copying Unix file permissions when using Compress-Archive to create Zip Archives

## PR Context

This PR fixes #36 by bitwise-or-ing the [FilesystemInfo.UnixFileMode](https://learn.microsoft.com/en-us/dotnet/api/system.io.filesysteminfo.unixfilemode?view=net-7.0) property into the [ZipArchiveEntry.ExternalAttributes](https://learn.microsoft.com/en-us/dotnet/api/system.io.compression.ziparchiveentry.externalattributes?view=net-7.0)