### PR TITLE
Adds LP to LiteralPath aliases

### DIFF
--- a/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
+++ b/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1
@@ -52,7 +52,7 @@ function Compress-Archive
         [parameter (mandatory=$true, ParameterSetName="LiteralPathWithForce", ValueFromPipeline=$false, ValueFromPipelineByPropertyName=$true)]
         [parameter (mandatory=$true, ParameterSetName="LiteralPathWithUpdate", ValueFromPipeline=$false, ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNullOrEmpty()]
-        [Alias("PSPath")]
+        [Alias("PSPath", "LP")]
         [string[]] $LiteralPath,
 
         [parameter (mandatory=$true,
@@ -269,7 +269,7 @@ function Expand-Archive
         ParameterSetName="LiteralPath",
         ValueFromPipelineByPropertyName=$true)]
         [ValidateNotNullOrEmpty()]
-        [Alias("PSPath")]
+        [Alias("PSPath", "LP")]
         [string] $LiteralPath,
 
         [parameter (mandatory=$false,


### PR DESCRIPTION
I noticed today that Compress-Archive and Expand-Archive don't have `-LP` as aliases to `-LiteralPath`, which makes them the only two built-in commands that I know of to not have this.